### PR TITLE
Simplify recursive module via JSX-V4

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -13,7 +13,7 @@
     }
   ],
   "suffix": ".bs.js",
-  "reason": { "react-jsx": 3 },
+  "jsx": {"version": 4, "mode": "automatic"},
   "bs-dependencies": ["@rescript/react"],
   "gentypeconfig": {
     "language": "typescript",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "re:start": "rescript build -w"
   },
   "dependencies": {
-    "@rescript/react": "^0.10.3",
+    "@rescript/react": "^0.11.0-rc.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -21,7 +21,7 @@
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.0",
     "gentype": "^4.5.0",
-    "rescript": "^10.0.1",
+    "rescript": "^10.1.0",
     "typescript": "^4.6.4",
     "vite": "^3.0.0"
   }

--- a/src/App.bs.js
+++ b/src/App.bs.js
@@ -4,6 +4,7 @@ import * as Curry from "rescript/lib/es6/curry.js";
 import * as React from "react";
 import * as Folder from "./Folder.bs.js";
 import * as Js_math from "rescript/lib/es6/js_math.js";
+import * as JsxRuntime from "react/jsx-runtime";
 
 import './App.css'
 ;
@@ -64,36 +65,56 @@ function reducer(state, action) {
   }
 }
 
-function App(Props) {
+function App(props) {
   var match = React.useReducer(reducer, initState);
   var dispatch = match[1];
   var state = match[0];
   var folderSelectedString = String(state.currentFolderId);
-  return React.createElement("div", {
+  return JsxRuntime.jsxs("div", {
+              children: [
+                JsxRuntime.jsx("div", {
+                      children: "Folder selected: " + folderSelectedString
+                    }),
+                JsxRuntime.jsxs("div", {
+                      children: [
+                        JsxRuntime.jsx("label", {
+                              children: "New folder name"
+                            }),
+                        JsxRuntime.jsx("input", {
+                              value: state.newFolderValue,
+                              onChange: (function (e) {
+                                  var updatedValue = e.currentTarget.value;
+                                  Curry._1(dispatch, {
+                                        TAG: /* FolderInputUpdated */0,
+                                        _0: updatedValue
+                                      });
+                                })
+                            }),
+                        JsxRuntime.jsx("button", {
+                              children: "Add Folder",
+                              type: "button",
+                              onClick: (function (param) {
+                                  Curry._1(dispatch, {
+                                        TAG: /* FolderAdded */2,
+                                        _0: Js_math.random_int(0, 100000)
+                                      });
+                                })
+                            })
+                      ]
+                    }),
+                JsxRuntime.jsx(Folder.Component.make, {
+                      currentFolder: state.rootFolder,
+                      handleClick: (function (id) {
+                          Curry._1(dispatch, {
+                                TAG: /* FolderSelected */3,
+                                _0: id
+                              });
+                        }),
+                      recLevel: 1
+                    })
+              ],
               className: "App"
-            }, React.createElement("div", undefined, "Folder selected: " + folderSelectedString), React.createElement("div", undefined, React.createElement("label", undefined, "New folder name"), React.createElement("input", {
-                      value: state.newFolderValue,
-                      onChange: (function (e) {
-                          var updatedValue = e.currentTarget.value;
-                          Curry._1(dispatch, {
-                                TAG: /* FolderInputUpdated */0,
-                                _0: updatedValue
-                              });
-                        })
-                    }), React.createElement("button", {
-                      type: "button",
-                      onClick: (function (param) {
-                          Curry._1(dispatch, {
-                                TAG: /* FolderAdded */2,
-                                _0: Js_math.random_int(0, 100000)
-                              });
-                        })
-                    }, "Add Folder")), React.createElement(Folder.Component.make, Curry._5(Folder.Component.makeProps, state.rootFolder, (function (id) {
-                        Curry._1(dispatch, {
-                              TAG: /* FolderSelected */3,
-                              _0: id
-                            });
-                      }), 1, undefined, undefined)));
+            });
 }
 
 var make = App;

--- a/src/App.gen.tsx
+++ b/src/App.gen.tsx
@@ -2,13 +2,13 @@
 /* eslint-disable import/first */
 
 
-import * as React from 'react';
-
 // @ts-ignore: Implicit any on import
 import * as AppBS__Es6Import from './App.bs';
 const AppBS: any = AppBS__Es6Import;
 
-// tslint:disable-next-line:interface-over-type-literal
-export type Props = {};
+import type {element as Jsx_element} from './Jsx.gen';
 
-export const make: React.ComponentType<{}> = AppBS.make;
+// tslint:disable-next-line:interface-over-type-literal
+export type props = {};
+
+export const make: (_1:props) => Jsx_element = AppBS.make;

--- a/src/Folder.bs.js
+++ b/src/Folder.bs.js
@@ -4,8 +4,8 @@ import * as Curry from "rescript/lib/es6/curry.js";
 import * as React from "react";
 import * as Belt_Array from "rescript/lib/es6/belt_Array.js";
 import * as Belt_Option from "rescript/lib/es6/belt_Option.js";
-import * as Caml_module from "rescript/lib/es6/caml_module.js";
 import * as Caml_option from "rescript/lib/es6/caml_option.js";
+import * as JsxRuntime from "react/jsx-runtime";
 
 function createNewFolder(name, id) {
   return {
@@ -48,75 +48,43 @@ function addFolderToRoot(rootFolder, targetFolderId, name, id) {
   }
 }
 
-var Component = Caml_module.init_mod([
-      "Folder.res",
-      60,
-      4
-    ], {
-      TAG: /* Module */0,
-      _0: [
-        [
-          /* Function */0,
-          "make"
-        ],
-        [
-          /* Function */0,
-          "makeProps"
-        ]
-      ]
-    });
-
-function Folder$Component(Props) {
-  var currentFolder = Props.currentFolder;
-  var handleClick = Props.handleClick;
-  var recLevel = Props.recLevel;
+function make(param) {
+  var recLevel = param.recLevel;
+  var handleClick = param.handleClick;
+  var currentFolder = param.currentFolder;
   var match = React.useState(function () {
         return false;
       });
   var setOpen = match[1];
-  return React.createElement("div", {
+  return JsxRuntime.jsxs("div", {
+              children: [
+                JsxRuntime.jsx("div", {
+                      children: currentFolder.name,
+                      role: "button",
+                      onClick: (function (param) {
+                          Curry._1(setOpen, (function (prev) {
+                                  return !prev;
+                                }));
+                          Curry._1(handleClick, currentFolder.id);
+                        })
+                    }),
+                match[0] ? Belt_Array.map(currentFolder.folders, (function (folder) {
+                          return JsxRuntime.jsx(Component.make, {
+                                      currentFolder: folder,
+                                      handleClick: handleClick,
+                                      recLevel: recLevel + 1 | 0
+                                    });
+                        })) : JsxRuntime.jsx(JsxRuntime.Fragment, {})
+              ],
               style: {
                 marginLeft: String((recLevel << 5)) + "px"
               }
-            }, React.createElement("div", {
-                  role: "button",
-                  onClick: (function (param) {
-                      Curry._1(setOpen, (function (prev) {
-                              return !prev;
-                            }));
-                      Curry._1(handleClick, currentFolder.id);
-                    })
-                }, currentFolder.name), match[0] ? Belt_Array.map(currentFolder.folders, (function (folder) {
-                      return React.createElement(Component.make, Curry._5(Component.makeProps, folder, handleClick, recLevel + 1 | 0, undefined, undefined));
-                    })) : React.createElement(React.Fragment, undefined));
+            });
 }
 
-Caml_module.update_mod({
-      TAG: /* Module */0,
-      _0: [
-        [
-          /* Function */0,
-          "make"
-        ],
-        [
-          /* Function */0,
-          "makeProps"
-        ]
-      ]
-    }, Component, {
-      make: Folder$Component,
-      makeProps: (function (prim0, prim1, prim2, prim3, prim4) {
-          var tmp = {
-            currentFolder: prim0,
-            handleClick: prim1,
-            recLevel: prim2
-          };
-          if (prim3 !== undefined) {
-            tmp.key = prim3;
-          }
-          return tmp;
-        })
-    });
+var Component = {
+  make: make
+};
 
 export {
   createNewFolder ,
@@ -125,4 +93,4 @@ export {
   addFolderToRoot ,
   Component ,
 }
-/* Component Not a pure module */
+/* react Not a pure module */

--- a/src/Folder.res
+++ b/src/Folder.res
@@ -48,18 +48,12 @@ let addFolderToRoot = (rootFolder: t, targetFolderId: int, name: string, id: int
   }
 }
 
+type componentProps = {currentFolder: t, handleClick: int => unit, recLevel: int}
+
 module rec Component: {
-  let make: {"currentFolder": t, "handleClick": int => unit, "recLevel": int} => React.element
-  let makeProps: (
-    ~currentFolder: t,
-    ~handleClick: int => unit,
-    ~recLevel: int,
-    ~key: string=?,
-    unit,
-  ) => {"currentFolder": t, "handleClick": int => unit, "recLevel": int}
+  let make: componentProps => Jsx.element
 } = {
-  @react.component
-  let make = (~currentFolder, ~handleClick, ~recLevel) => {
+  let make = ({currentFolder, handleClick, recLevel}) => {
     let (isOpen, setOpen) = React.useState(_ => false)
     <div style={ReactDOM.Style.make(~marginLeft=(recLevel * 32)->Belt.Int.toString ++ "px", ())}>
       <div


### PR DESCRIPTION
Hi!

I saw your newest video and wanted to demonstrate how you can simplify the usage of recursive module react components thanks to the new JSX V4 transform, which has been introduced in ReScript 10.1. 

It allows to type the props as a record and call them just as you would in TypeScript, e.g. with `props.recLevel`, also you don't even need the `@react.component` annotation anymore (which means `makeProps` is gone)!

Keep in mind that annotating with `@react.component` is still the more convenient way in most cases, but for special cases like React context providers or recursive components, it seems to be the way to go IMO.

Check out the docs: https://rescript-lang.org/docs/react/latest/migrate-from-v3#migration-of-v3-components

btw: Thank you for creating so much ReScript video content!